### PR TITLE
feat: add github issue management to go flaky tests

### DIFF
--- a/actions/go-flaky-tests/CHANGELOG.md
+++ b/actions/go-flaky-tests/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Initial implementation of flaky test analysis action
 - Loki integration for fetching test failure logs
 - Git history analysis to find test authors
+- GitHub issue creation and management for flaky tests
+- Dry run mode for testing without creating issues
 - Comprehensive test suite with golden file testing
 
 ### Features
@@ -14,4 +16,6 @@
 - **Loki Log Analysis**: Fetches and parses test failure logs using LogQL
 - **Flaky Test Detection**: Identifies tests that fail inconsistently across branches
 - **Git Author Tracking**: Finds recent commits that modified flaky tests
+- **GitHub Integration**: Creates and updates issues with detailed test information
 - **Configurable Limits**: Top-K filtering to focus on most problematic tests
+- **Rich Issue Templates**: Detailed issue descriptions with investigation guidance

--- a/actions/go-flaky-tests/action.yaml
+++ b/actions/go-flaky-tests/action.yaml
@@ -23,6 +23,14 @@ inputs:
     description: "Relative path to the directory with a git repository"
     required: false
     default: ${{ github.workspace }}
+  github-token:
+    description: "GitHub token for repository access"
+    required: false
+    default: ${{ github.token }}
+  skip-posting-issues:
+    description: "Skip creating/updating GitHub issues (dry-run mode)"
+    required: false
+    default: "true"
   top-k:
     description: "Include only the top K flaky tests by distinct branches count in analysis"
     required: false
@@ -36,6 +44,13 @@ runs:
       with:
         go-version: "1.25"
 
+    - name: Setup GitHub CLI
+      run: |
+        # GitHub CLI is pre-installed on GitHub Actions runners
+        # Just verify it's available and authenticated
+        gh --version
+      shell: bash
+
     - name: Build and run analyzer
       shell: bash
       run: |
@@ -48,5 +63,7 @@ runs:
         LOKI_PASSWORD: ${{ inputs.loki-password }}
         REPOSITORY: ${{ inputs.repository }}
         TIME_RANGE: ${{ inputs.time-range }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
         REPOSITORY_DIRECTORY: ${{ inputs.repository-directory }}
+        SKIP_POSTING_ISSUES: ${{ inputs.skip-posting-issues }}
         TOP_K: ${{ inputs.top-k }}

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
@@ -19,10 +19,19 @@ type GitClient interface {
 	TestCommits(filePath, testName string) ([]CommitInfo, error)
 }
 
+type GitHubClient interface {
+	GetUsernameForCommit(commitHash string) (string, error)
+	CreateOrUpdateIssue(test FlakyTest) error
+	SearchForExistingIssue(issueTitle string) (string, error)
+	AddCommentToIssue(issueURL string, test FlakyTest) error
+	ReopenIssue(issueURL string) error
+}
+
 type TestFailureAnalyzer struct {
-	lokiClient LokiClient
-	gitClient  GitClient
-	fileSystem FileSystem
+	lokiClient   LokiClient
+	gitClient    GitClient
+	githubClient GitHubClient
+	fileSystem   FileSystem
 }
 
 type CommitInfo struct {
@@ -74,20 +83,22 @@ func (fs *DefaultFileSystem) WriteFile(filename string, data []byte, perm os.Fil
 	return os.WriteFile(filename, data, perm)
 }
 
-func NewTestFailureAnalyzer(loki LokiClient, git GitClient, fs FileSystem) *TestFailureAnalyzer {
+func NewTestFailureAnalyzer(loki LokiClient, git GitClient, github GitHubClient, fs FileSystem) *TestFailureAnalyzer {
 	return &TestFailureAnalyzer{
-		lokiClient: loki,
-		gitClient:  git,
-		fileSystem: fs,
+		lokiClient:   loki,
+		gitClient:    git,
+		githubClient: github,
+		fileSystem:   fs,
 	}
 }
 
 func NewDefaultTestFailureAnalyzer(config Config) *TestFailureAnalyzer {
 	lokiClient := NewDefaultLokiClient(config)
 	gitClient := NewDefaultGitClient(config)
+	githubClient := NewDefaultGitHubClient(config)
 	fileSystem := &DefaultFileSystem{}
 
-	return NewTestFailureAnalyzer(lokiClient, gitClient, fileSystem)
+	return NewTestFailureAnalyzer(lokiClient, gitClient, githubClient, fileSystem)
 }
 
 func (t *TestFailureAnalyzer) AnalyzeFailures(config Config) (*FailuresReport, error) {
@@ -165,8 +176,26 @@ func (t *TestFailureAnalyzer) AnalyzeFailures(config Config) (*FailuresReport, e
 }
 
 func (t *TestFailureAnalyzer) ActionReport(report *FailuresReport, config Config) error {
-	log.Printf("📝 Report generated successfully - no additional actions in this version")
-	log.Printf("✅ Analysis complete!")
+	if report == nil || len(report.FlakyTests) == 0 {
+		log.Printf("📝 No flaky tests to enact - skipping GitHub issue creation")
+		return nil
+	}
+
+	if config.SkipPostingIssues {
+		log.Printf("🔍 Dry run mode: Generating issue previews...")
+		err := t.previewIssuesForFlakyTests(report.FlakyTests)
+		if err != nil {
+			return fmt.Errorf("failed to preview GitHub issues: %w", err)
+		}
+	} else {
+		log.Printf("📝 Creating GitHub issues for flaky tests...")
+		err := t.createIssuesForFlakyTests(report.FlakyTests)
+		if err != nil {
+			return fmt.Errorf("failed to create GitHub issues: %w", err)
+		}
+	}
+
+	log.Printf("✅ Report enactment complete!")
 	return nil
 }
 
@@ -229,6 +258,45 @@ func (t *TestFailureAnalyzer) findTestAuthors(flakyTests []FlakyTest) error {
 			}
 		}
 	}
+	return nil
+}
+
+func (t *TestFailureAnalyzer) createIssuesForFlakyTests(flakyTests []FlakyTest) error {
+	for _, test := range flakyTests {
+		err := t.githubClient.CreateOrUpdateIssue(test)
+		if err != nil {
+			log.Printf("Warning: failed to create issue for test %s: %v", test.TestName, err)
+		}
+	}
+	return nil
+}
+
+func (t *TestFailureAnalyzer) previewIssuesForFlakyTests(flakyTests []FlakyTest) error {
+	for _, test := range flakyTests {
+		err := previewIssueForTest(test)
+		if err != nil {
+			log.Printf("Warning: failed to preview issue for test %s: %v", test.TestName, err)
+		}
+	}
+	return nil
+}
+
+func previewIssueForTest(test FlakyTest) error {
+	issueTitle := fmt.Sprintf("Flaky test: %s", test.TestName)
+
+	log.Printf("📄 Issue preview for %s:", test.TestName)
+	log.Printf("Title: %s", issueTitle)
+	log.Printf("Labels: flaky-test")
+
+	log.Printf("Initial Body: This test appears to be flaky based on log analysis with %d failures", test.TotalFailures)
+	log.Printf("────────────────────────────────────────────────────────────────────────")
+
+	log.Printf("Comment Body: Found %d total failures across branches", test.TotalFailures)
+	if len(test.RecentCommits) > 0 {
+		log.Printf("Recent authors: %v", test.RecentCommits)
+	}
+	log.Printf("────────────────────────────────────────────────────────────────────────")
+
 	return nil
 }
 

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
@@ -183,7 +183,7 @@ func (t *TestFailureAnalyzer) ActionReport(report *FailuresReport, config Config
 
 	if config.SkipPostingIssues {
 		log.Printf("🔍 Dry run mode: Generating issue previews...")
-		err := t.previewIssuesForFlakyTests(report.FlakyTests)
+		err := t.previewIssuesForFlakyTests(report.FlakyTests, config)
 		if err != nil {
 			return fmt.Errorf("failed to preview GitHub issues: %w", err)
 		}
@@ -273,9 +273,9 @@ func (t *TestFailureAnalyzer) createIssuesForFlakyTests(flakyTests []FlakyTest) 
 	return nil
 }
 
-func (t *TestFailureAnalyzer) previewIssuesForFlakyTests(flakyTests []FlakyTest) error {
+func (t *TestFailureAnalyzer) previewIssuesForFlakyTests(flakyTests []FlakyTest, config Config) error {
 	for _, test := range flakyTests {
-		err := previewIssueForTest(test)
+		err := previewIssueForTest(test, config)
 		if err != nil {
 			log.Printf("Warning: failed to preview issue for test %s: %v", test.TestName, err)
 		}
@@ -283,7 +283,7 @@ func (t *TestFailureAnalyzer) previewIssuesForFlakyTests(flakyTests []FlakyTest)
 	return nil
 }
 
-func previewIssueForTest(test FlakyTest) error {
+func previewIssueForTest(test FlakyTest, config Config) error {
 	issueTitle := fmt.Sprintf("Flaky test: %s", test.TestName)
 
 	log.Printf("📄 Would create issue for %s:", test.TestName)
@@ -298,7 +298,7 @@ func previewIssueForTest(test FlakyTest) error {
 		return nil
 	}
 
-	commentBody, err := generateCommentBody(test)
+	commentBody, err := generateCommentBody(test, config)
 	if err != nil {
 		log.Printf("Warning: failed to generate comment body preview: %v", err)
 		return nil

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
@@ -284,7 +284,7 @@ func (t *TestFailureAnalyzer) previewIssuesForFlakyTests(flakyTests []FlakyTest,
 }
 
 func previewIssueForTest(test FlakyTest, config Config) error {
-	issueTitle := fmt.Sprintf("Flaky test: %s", test.TestName)
+	issueTitle := fmt.Sprintf("Flaky %s", test.TestName)
 
 	log.Printf("📄 Would create issue for %s:", test.TestName)
 	log.Printf("Title: %s", issueTitle)

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/config.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Repository          string
 	TimeRange           string
 	RepositoryDirectory string
+	SkipPostingIssues   bool
 	TopK                int
 }
 
@@ -23,6 +24,7 @@ func getConfigFromEnv() Config {
 		Repository:          os.Getenv("REPOSITORY"),
 		TimeRange:           getEnvWithDefault("TIME_RANGE", "24h"),
 		RepositoryDirectory: getEnvWithDefault("REPOSITORY_DIRECTORY", "."),
+		SkipPostingIssues:   getBoolEnvWithDefault("SKIP_POSTING_ISSUES", true),
 		TopK:                getIntEnvWithDefault("TOP_K", 3),
 	}
 }
@@ -30,6 +32,13 @@ func getConfigFromEnv() Config {
 func getEnvWithDefault(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
+	}
+	return defaultValue
+}
+
+func getBoolEnvWithDefault(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		return value == "true" || value == "1"
 	}
 	return defaultValue
 }

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/git.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/git.go
@@ -52,10 +52,11 @@ func findTestFilePath(repoDir, testName string) (string, error) {
 }
 
 func getFileAuthors(config Config, filePath, testName string) ([]CommitInfo, error) {
-	return getFileAuthorsWithClient(config.RepositoryDirectory, filePath, testName)
+	githubClient := NewDefaultGitHubClient(config)
+	return getFileAuthorsWithClient(config.RepositoryDirectory, filePath, testName, githubClient)
 }
 
-func getFileAuthorsWithClient(repoDir, filePath, testName string) ([]CommitInfo, error) {
+func getFileAuthorsWithClient(repoDir, filePath, testName string, githubClient GitHubClient) ([]CommitInfo, error) {
 	// Get 10 commits, because some of them might just be only bots.
 	cmd := exec.Command("git", "log", "-10", "-L", fmt.Sprintf(":%s:%s", testName, filePath), "--pretty=format:%H|%ct|%s|%an", "-s")
 	cmd.Dir = repoDir

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
@@ -10,7 +10,6 @@ import (
 	"time"
 )
 
-
 type DefaultGitHubClient struct {
 	config Config
 }

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
@@ -219,7 +219,7 @@ This test failed **{{.TotalFailures}} times** across **{{len .BranchCounts}} dif
 ### Who might know about this?
 {{- if .RecentCommits}}
 {{- range .RecentCommits}}
-- @{{.Author}} - made a relevant commit on {{.Timestamp | formatDate}}: {{.Hash}} "{{.Title}}"
+- {{.Author}} - made a relevant commit on {{.Timestamp | formatDate}}: {{.Hash}} "{{.Title}}"
 {{- end}}
 
 If any of you have a few minutes, could you take a look? You might have context on what could be causing the flakiness.
@@ -231,7 +231,7 @@ _No recent changes to the test definition._
 
 ### Recent failures
 {{- range .ExampleWorkflows}}
-- [Failed run]({{.}}) - check previous attempts' logs for clues
+- [Failed run]({{.RunURL}}) - ` + "`{{.JobName}}`" + ` (Attempt #&NoBreak;{{.Attempt}})
 {{- end}}
 {{- end}}
 

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
@@ -219,7 +219,7 @@ This test failed **{{.TotalFailures}} times** across **{{len .BranchCounts}} dif
 ### Who might know about this?
 {{- if .RecentCommits}}
 {{- range .RecentCommits}}
-- {{.Author}} - made a relevant commit on {{.Timestamp | formatDate}}: {{.Hash}} "{{.Title}}"
+- @{{.Author}} - made a relevant commit on {{.Timestamp | formatDate}}: {{.Hash}} "{{.Title}}"
 {{- end}}
 
 If any of you have a few minutes, could you take a look? You might have context on what could be causing the flakiness.

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
@@ -209,7 +209,7 @@ This issue tracks a flaky test that has been detected failing inconsistently. Ea
 - **Can't fix it right now?** Consider adding logs and metrics so that next time it's easier to debug.
 - **Obsolete test?** Maybe it's time to remove it or skip it with ` + "`t.Skip()`" + `
 
-_This test has been identified as flaky by [analyze-test-failures](https://github.com/grafana/shared-workflows/tree/main/actions/analyze-test-failures)._
+_This test has been identified as flaky by [go-flaky-tests](https://github.com/grafana/shared-workflows/tree/main/actions/go-flaky-tests)._
 `
 
 const commentTemplate = `## 🚨 Hey there! This test is still being flaky

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
@@ -36,11 +36,11 @@ func (gh *DefaultGitHubClient) GetUsernameForCommit(commitHash string) (string, 
 		return response[0].Author.Login, nil
 	}
 
-	return "", fmt.Errorf("no GitHub username found for commit %s", commitHash)
+	return "", fmt.Errorf("no GitHub username found for commit %s; GitHub response %s", commitHash, string(result))
 }
 
 func (gh *DefaultGitHubClient) CreateOrUpdateIssue(test FlakyTest) error {
-	issueTitle := fmt.Sprintf("Flaky test: %s", test.TestName)
+	issueTitle := fmt.Sprintf("Flaky %s", test.TestName)
 
 	existingIssueURL, err := gh.SearchForExistingIssue(issueTitle)
 	if err != nil {
@@ -212,24 +212,24 @@ This issue tracks a flaky test that has been detected failing inconsistently. Ea
 _This test has been identified as flaky by [go-flaky-tests](https://github.com/grafana/shared-workflows/tree/main/actions/go-flaky-tests)._
 `
 
-const commentTemplate = `## 🚨 Hey there! This test is still being flaky
+const commentTemplate = `## Hey there! This test is still being flaky
 
 This test failed **{{.TotalFailures}} times** across **{{len .BranchCounts}} different branches** in the last {{.TimeRange}}.
 
-### 🕵️ Who might know about this?
+### Who might know about this?
 {{- if .RecentCommits}}
 {{- range .RecentCommits}}
 - {{.Author}} - made a relevant commit on {{.Timestamp | formatDate}}: {{.Hash}} "{{.Title}}"
 {{- end}}
 
-👆 If any of you have a few minutes, could you take a look? You might have context on what could be causing the flakiness.
+If any of you have a few minutes, could you take a look? You might have context on what could be causing the flakiness.
 {{- else}}
 _No recent changes to the test definition._
 {{- end}}
 
 {{- if .ExampleWorkflows}}
 
-### 💥 Recent failures
+### Recent failures
 {{- range .ExampleWorkflows}}
 - [Failed run]({{.}}) - check previous attempts' logs for clues
 {{- end}}
@@ -237,7 +237,7 @@ _No recent changes to the test definition._
 
 **💡 Check the issue description above for investigation tips and next steps!**
 
-Thanks for helping keep our tests reliable! 🙏`
+Thanks for helping keep our tests reliable!`
 
 func generateInitialIssueBody(test FlakyTest) (string, error) {
 	tmpl, err := template.New("initialIssueBody").Parse(initialIssueBodyTemplate)

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"text/template"
+	"time"
+)
+
+
+type DefaultGitHubClient struct {
+	config Config
+}
+
+func NewDefaultGitHubClient(config Config) *DefaultGitHubClient {
+	return &DefaultGitHubClient{config: config}
+}
+
+func (gh *DefaultGitHubClient) GetUsernameForCommit(commitHash string) (string, error) {
+	cmd := exec.Command("gh", "search", "commits", "--hash", commitHash, "--json", "author")
+
+	result, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to search commit: %w (output: %s)", err, string(result))
+	}
+
+	var response GitHubCommitSearchResponse
+
+	if err := json.Unmarshal(result, &response); err != nil {
+		return "", fmt.Errorf("failed to parse GitHub API response: %w", err)
+	}
+
+	if len(response) > 0 && response[0].Author.Login != "" {
+		return response[0].Author.Login, nil
+	}
+
+	return "", fmt.Errorf("no GitHub username found for commit %s", commitHash)
+}
+
+func (gh *DefaultGitHubClient) CreateOrUpdateIssue(test FlakyTest) error {
+	issueTitle := fmt.Sprintf("Flaky test: %s", test.TestName)
+
+	existingIssueURL, err := gh.SearchForExistingIssue(issueTitle)
+	if err != nil {
+		log.Printf("Warning: failed to search for existing issue: %v", err)
+	}
+
+	if existingIssueURL != "" {
+		log.Printf("📝 Found existing issue for %s, adding comment: %s", test.TestName, existingIssueURL)
+		return gh.AddCommentToIssue(existingIssueURL, test)
+	}
+
+	log.Printf("📝 Creating new issue for flaky test: %s", test.TestName)
+	issueBody, err := generateInitialIssueBody(test)
+	if err != nil {
+		return fmt.Errorf("failed to generate issue body: %w", err)
+	}
+
+	cmd := exec.Command("gh", "issue", "create",
+		"--repo", gh.config.Repository,
+		"--title", issueTitle,
+		"--body", issueBody,
+		"--label", "flaky-test")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create GitHub issue: %w, output: %s", err, string(output))
+	}
+
+	log.Printf("📝 Created GitHub issue: %s", strings.TrimSpace(string(output)))
+
+	issueURL := strings.TrimSpace(string(output))
+	return gh.AddCommentToIssue(issueURL, test)
+}
+
+func (gh *DefaultGitHubClient) SearchForExistingIssue(issueTitle string) (string, error) {
+	cmd := exec.Command("gh", "issue", "list",
+		"--repo", gh.config.Repository,
+		"--search", fmt.Sprintf("\"%s\"", issueTitle),
+		"--state", "all",
+		"--json", "url,title,state")
+
+	result, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to search issues: %w", err)
+	}
+
+	var issues []struct {
+		URL   string `json:"url"`
+		Title string `json:"title"`
+		State string `json:"state"`
+	}
+
+	if err := json.Unmarshal(result, &issues); err != nil {
+		return "", fmt.Errorf("failed to parse issue search response: %w", err)
+	}
+
+	for _, issue := range issues {
+		if issue.Title == issueTitle {
+			if issue.State == "CLOSED" {
+				log.Printf("🔄 Reopening closed issue for %s: %s", issueTitle, issue.URL)
+				err := gh.ReopenIssue(issue.URL)
+				if err != nil {
+					log.Printf("Warning: failed to reopen issue %s: %v", issue.URL, err)
+				}
+			}
+			return issue.URL, nil
+		}
+	}
+
+	return "", nil
+}
+
+func (gh *DefaultGitHubClient) AddCommentToIssue(issueURL string, test FlakyTest) error {
+	commentBody, err := generateCommentBody(test)
+	if err != nil {
+		return fmt.Errorf("failed to generate comment body: %w", err)
+	}
+
+	cmd := exec.Command("gh", "issue", "comment", issueURL, "--body", commentBody)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to add comment to GitHub issue: %w, output: %s", err, string(output))
+	}
+
+	log.Printf("📝 Added comment to GitHub issue: %s", issueURL)
+
+	issue, err := gh.getIssueState(issueURL)
+	if err != nil {
+		log.Printf("Warning: failed to check issue state: %v", err)
+		return nil
+	}
+
+	if issue.State == "closed" {
+		log.Printf("📝 Issue is closed, reopening: %s", issueURL)
+		err := gh.ReopenIssue(issueURL)
+		if err != nil {
+			log.Printf("Warning: failed to reopen issue: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (gh *DefaultGitHubClient) ReopenIssue(issueURL string) error {
+	cmd := exec.Command("gh", "issue", "reopen", issueURL, "--repo", gh.config.Repository)
+
+	result, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to reopen issue: %w (output: %s)", err, string(result))
+	}
+
+	log.Printf("✅ Reopened issue: %s", issueURL)
+	return nil
+}
+
+func (gh *DefaultGitHubClient) getIssueState(issueURL string) (*GitHubIssue, error) {
+	cmd := exec.Command("gh", "issue", "view", issueURL,
+		"--repo", gh.config.Repository,
+		"--json", "state,url,title")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get issue state: %w, output: %s", err, string(output))
+	}
+
+	var issue GitHubIssue
+	if err := json.Unmarshal(output, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse issue state response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+type GitHubIssue struct {
+	State string `json:"state"`
+	URL   string `json:"url"`
+	Title string `json:"title"`
+}
+
+type GitHubCommitSearchResponse []GitHubCommitSearchItem
+
+type GitHubCommitSearchItem struct {
+	Author GitHubAuthor `json:"author"`
+}
+
+type GitHubAuthor struct {
+	Login string `json:"login"`
+}
+
+const initialIssueBodyTemplate = `
+## ` + "`{{.TestName}}`\n\n`{{.FilePath}}`" + `
+
+### About This Issue
+This issue tracks a flaky test that has been detected failing inconsistently. Each week our analysis tool runs and detects this test as flaky, it will add a comment below with recent failure data and who might be able to help.
+
+### 🔍 How to investigate
+1. **Run it locally** to see if you can reproduce: ` + "`go test -count=10000 -run {{.TestName}} ./...`" + `
+2. **Check the failure logs** in the comments below - they might show a pattern
+3. **Look for timing issues** - race conditions, timeouts, or external dependencies
+4. **Review recent changes** - check commits that modified this test or the code under test recently
+
+### 🎯 Next steps
+- **Can you fix it?** Great! That would help the whole team
+- **Need help?** Ask someone who has worked on this area recently
+- **Can't fix it right now?** Consider adding logs and metrics so that next time it's easier to debug.
+- **Obsolete test?** Maybe it's time to remove it or skip it with ` + "`t.Skip()`" + `
+
+_This test has been identified as flaky by [analyze-test-failures](https://github.com/grafana/shared-workflows/tree/main/actions/analyze-test-failures)._
+`
+
+const commentTemplate = `## 🚨 Hey there! This test is still being flaky
+
+This test failed **{{.TotalFailures}} times** across **{{len .BranchCounts}} different branches** in the last 7 days.
+
+{{- if .RecentCommits}}
+
+### 🕵️ Who might know about this?
+{{- range .RecentCommits}}
+- {{.Author}} - made a relevant commit on {{.Timestamp | formatDate}}: {{.Hash}} "{{.Title}}"
+{{- end}}
+
+👆 If any of you have a few minutes, could you take a look? You might have context on what could be causing the flakiness.
+{{- end}}
+
+{{- if .ExampleWorkflows}}
+
+### 💥 Recent failures
+{{- range .ExampleWorkflows}}
+- [Failed run]({{.}}) - check previous attempts' logs for clues
+{{- end}}
+{{- end}}
+
+**💡 Check the issue description above for investigation tips and next steps!**
+
+Thanks for helping keep our tests reliable! 🙏`
+
+func generateInitialIssueBody(test FlakyTest) (string, error) {
+	tmpl, err := template.New("initialIssueBody").Parse(initialIssueBodyTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse initial issue template: %w", err)
+	}
+
+	var body strings.Builder
+	if err := tmpl.Execute(&body, test); err != nil {
+		return "", fmt.Errorf("failed to execute initial issue template: %w", err)
+	}
+
+	return body.String(), nil
+}
+
+func generateCommentBody(test FlakyTest) (string, error) {
+	tmpl, err := template.New("comment").Funcs(template.FuncMap{
+		"formatDate": func(t time.Time) string {
+			return t.Format("2006-01-02")
+		},
+	}).Parse(commentTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse comment template: %w", err)
+	}
+
+	var body strings.Builder
+	if err := tmpl.Execute(&body, test); err != nil {
+		return "", fmt.Errorf("failed to execute comment template: %w", err)
+	}
+
+	return body.String(), nil
+}

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/github.go
@@ -216,14 +216,15 @@ const commentTemplate = `## 🚨 Hey there! This test is still being flaky
 
 This test failed **{{.TotalFailures}} times** across **{{len .BranchCounts}} different branches** in the last 7 days.
 
-{{- if .RecentCommits}}
-
 ### 🕵️ Who might know about this?
+{{- if .RecentCommits}}
 {{- range .RecentCommits}}
 - {{.Author}} - made a relevant commit on {{.Timestamp | formatDate}}: {{.Hash}} "{{.Title}}"
 {{- end}}
 
 👆 If any of you have a few minutes, could you take a look? You might have context on what could be causing the flakiness.
+{{- else}}
+_No recent changes to the test definition._
 {{- end}}
 
 {{- if .ExampleWorkflows}}

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/main_test.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/main_test.go
@@ -83,7 +83,7 @@ func (m *MockGitHubClient) CreateOrUpdateIssue(test FlakyTest) error {
 	if m.createIssueErr != nil {
 		return m.createIssueErr
 	}
-	issueTitle := fmt.Sprintf("Flaky test: %s", test.TestName)
+	issueTitle := fmt.Sprintf("Flaky %s", test.TestName)
 
 	// Check if issue exists
 	if existingURL, exists := m.existingIssues[issueTitle]; exists {

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/main_test.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/main_test.go
@@ -203,10 +203,10 @@ func TestAnalyzer_AnalyzeFailures_Success(t *testing.T) {
 		},
 		authors: map[string][]CommitInfo{
 			"TestUserLogin": {
-				{Hash: "abc123", Author: "alice", Timestamp: time.Now().AddDate(0, -1, 0), Title: "Fix user login"},
+				{Hash: "abc123", Timestamp: time.Now().AddDate(0, -1, 0), Title: "Fix user login"},
 			},
 			"TestPayment": {
-				{Hash: "def456", Author: "bob", Timestamp: time.Now().AddDate(0, -2, 0), Title: "Update payment logic"},
+				{Hash: "def456", Timestamp: time.Now().AddDate(0, -2, 0), Title: "Update payment logic"},
 			},
 		},
 	}
@@ -445,10 +445,10 @@ func TestAnalyzer_Run_Success(t *testing.T) {
 		},
 		authors: map[string][]CommitInfo{
 			"TestUserLogin": {
-				{Hash: "abc123", Author: "alice", Timestamp: time.Now().AddDate(0, -1, 0), Title: "Fix user login"},
+				{Hash: "abc123", Timestamp: time.Now().AddDate(0, -1, 0), Title: "Fix user login"},
 			},
 			"TestPayment": {
-				{Hash: "def456", Author: "bob", Timestamp: time.Now().AddDate(0, -2, 0), Title: "Update payment logic"},
+				{Hash: "def456", Timestamp: time.Now().AddDate(0, -2, 0), Title: "Update payment logic"},
 			},
 		},
 	}
@@ -796,15 +796,15 @@ func TestAnalyzer_Run_GoldenFiles(t *testing.T) {
 					},
 					authors: map[string][]CommitInfo{
 						"TestDatabaseConnection": {
-							{Hash: "abc123def456", Author: "alice", Timestamp: mustParseTime("2024-01-15T10:30:00Z"), Title: "Optimize database connection pooling"},
-							{Hash: "789ghi012jkl", Author: "bob", Timestamp: mustParseTime("2024-01-10T14:22:00Z"), Title: "Add connection timeout handling"},
+							{Hash: "abc123def456", Timestamp: mustParseTime("2024-01-15T10:30:00Z"), Title: "Optimize database connection pooling"},
+							{Hash: "789ghi012jkl", Timestamp: mustParseTime("2024-01-10T14:22:00Z"), Title: "Add connection timeout handling"},
 						},
 						"TestUserAuthentication": {
-							{Hash: "345mno678pqr", Author: "charlie", Timestamp: mustParseTime("2024-01-12T09:15:00Z"), Title: "Implement OAuth2 authentication flow"},
+							{Hash: "345mno678pqr", Timestamp: mustParseTime("2024-01-12T09:15:00Z"), Title: "Implement OAuth2 authentication flow"},
 						},
 						"TestPaymentProcessing": {
-							{Hash: "901stu234vwx", Author: "dave", Timestamp: mustParseTime("2024-01-08T16:45:00Z"), Title: "Add Stripe payment integration"},
-							{Hash: "567yza890bcd", Author: "eve", Timestamp: mustParseTime("2024-01-05T11:30:00Z"), Title: "Refactor payment processing logic"},
+							{Hash: "901stu234vwx", Timestamp: mustParseTime("2024-01-08T16:45:00Z"), Title: "Add Stripe payment integration"},
+							{Hash: "567yza890bcd", Timestamp: mustParseTime("2024-01-05T11:30:00Z"), Title: "Refactor payment processing logic"},
 						},
 					},
 				}

--- a/actions/go-flaky-tests/run-local.sh
+++ b/actions/go-flaky-tests/run-local.sh
@@ -21,13 +21,14 @@ usage() {
     echo "  --loki-password PASS          Password for Loki authentication"
     echo "  --repository REPO             Repository name in 'owner/repo' format (required)"
     echo "  --time-range RANGE            Time range for query (default: ${DEFAULT_TIME_RANGE})"
+    echo "  --github-token TOKEN          GitHub token for API access"
     echo "  --repository-directory DIR    Repository directory (default: current directory)"
     echo "  --skip-posting-issues BOOL    Skip creating GitHub issues (default: ${DEFAULT_SKIP_POSTING_ISSUES})"
     echo "  --top-k NUM                   Number of top flaky tests to analyze (default: ${DEFAULT_TOP_K})"
     echo ""
     echo "Environment variables:"
     echo "  LOKI_URL, LOKI_USERNAME, LOKI_PASSWORD, REPOSITORY, TIME_RANGE,"
-    echo "  REPOSITORY_DIRECTORY, SKIP_POSTING_ISSUES, TOP_K"
+    echo "  REPOSITORY_DIRECTORY, GITHUB_TOKEN, SKIP_POSTING_ISSUES, TOP_K"
     echo ""
     echo "Example:"
     echo "  $0 --loki-url http://localhost:3100 --repository myorg/myrepo --time-range 7d"
@@ -58,6 +59,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --time-range)
             TIME_RANGE="$2"
+            shift 2
+            ;;
+        --github-token)
+            GITHUB_TOKEN="$2"
             shift 2
             ;;
         --repository-directory)
@@ -102,6 +107,7 @@ export LOKI_USERNAME
 export LOKI_PASSWORD
 export REPOSITORY
 export TIME_RANGE
+export GITHUB_TOKEN
 export REPOSITORY_DIRECTORY
 export SKIP_POSTING_ISSUES
 export TOP_K


### PR DESCRIPTION
## Summary

Completes the flaky test detection system from https://github.com/dimitarvdimitrov/shared-workflows/pull/2 by adding comprehensive GitHub issue management. This enables automatic creation and updating of issues for flaky tests.

This is the last of 3 PRs for go-flaky-tests.

## What's Added

- **GitHub Integration**: Full `GitHubClient` implementation using GitHub CLI
- **Issue Management**: Creates new issues and updates existing ones for flaky tests
- **Issue Handling**: Searches for existing issues and reopens closed ones when tests become flaky again
- **Dry Run Mode**: Preview functionality that shows exactly what issues would be created

## Key Components

- `github.go`: Complete GitHub operations with proper error handling and issue lifecycle management. The GitHub integration uses the GitHub CLI (`gh`) for all operations
- Enhanced `analyzer.go`: Full implementation of issue creation and preview functionality
- Updated action configuration: Adds `github-token` input parameter and `skip-posting-issues` control
- Comprehensive GitHub integration test coverage
